### PR TITLE
Remove nullable type warning

### DIFF
--- a/src/DNS.php
+++ b/src/DNS.php
@@ -34,7 +34,7 @@ class DNS {
 				}
 		}
 
-		public static function query( string $domainName, Type $type, string $useSpecificServer = null, $queryRecursionCounter = 0 ): DNSQueryResult {
+		public static function query( string $domainName, Type $type, ?string $useSpecificServer = null, $queryRecursionCounter = 0): DNSQueryResult {
 				$queryRecursionCounter ++;
 				if ( $queryRecursionCounter > 5 ) {
 						throw new RuntimeException( 'Too many recursions, something is wrong with the response from all nameservers' );
@@ -95,7 +95,7 @@ class DNS {
 				return $dnsQueryResults;
 		}
 
-		private static function requestAnswer( string $dnsQuery, string $specificServer = null ): array {
+		private static function requestAnswer( string $dnsQuery, ?string $specificServer = null ): array {
 				if ( $specificServer === null ) {
 						$serverCount = count( self::$servers );
 						if ( $serverCount === 0 ) {

--- a/src/DNS.php
+++ b/src/DNS.php
@@ -34,7 +34,7 @@ class DNS {
 				}
 		}
 
-		public static function query( string $domainName, Type $type, ?string $useSpecificServer = null, $queryRecursionCounter = 0): DNSQueryResult {
+		public static function query( string $domainName, Type $type, ?string $useSpecificServer = null, $queryRecursionCounter = 0 ): DNSQueryResult {
 				$queryRecursionCounter ++;
 				if ( $queryRecursionCounter > 5 ) {
 						throw new RuntimeException( 'Too many recursions, something is wrong with the response from all nameservers' );


### PR DESCRIPTION
I get

```
PHP Deprecated:  LJPc\DoH\DNS::query(): Implicitly marking parameter $useSpecificServer as nullable is deprecated, the explicit nullable type must be used instead in /Users/karelbilek/Pure-PHP-DoH-Client/src/DNS.php
```

warnings. It seems this fixes them easily without a sweat